### PR TITLE
Improve project search with multi-word AND logic

### DIFF
--- a/src/TaskPilot.Core/ViewModel/ProjectsBrowserViewModel.cs
+++ b/src/TaskPilot.Core/ViewModel/ProjectsBrowserViewModel.cs
@@ -438,10 +438,18 @@ namespace TaskPilot.Core.ViewModel
                 // Filter by search query
                 if (!string.IsNullOrWhiteSpace(SearchQuery))
                 {
-                    var query = SearchQuery.Trim().ToLowerInvariant();
+                    var query = SearchQuery.Trim();
+                    var words = query.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+                    
                     filtered = filtered.Where(p =>
-                        p.Name.ToLowerInvariant().Contains(query) ||
-                        (p.Description?.ToLowerInvariant().Contains(query) ?? false));
+                    {
+                        var searchableText = $"{p.Name} {p.Description}".ToLowerInvariant();
+                        
+                        // All words must match (AND logic)
+                        return words.All(word => 
+                            searchableText.Contains(word.ToLowerInvariant())
+                        );
+                    });
                 }
 
                 // Sort

--- a/src/TaskPilot.Desktop.WinApp/Pages/ProjectsBrowser.xaml
+++ b/src/TaskPilot.Desktop.WinApp/Pages/ProjectsBrowser.xaml
@@ -114,7 +114,8 @@
                                         PlaceholderText="Search projects..."
                                         QueryIcon="Find"
                                         Text="{x:Bind ViewModel.SearchQuery, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
-                                        VerticalAlignment="Center"/>
+                                        VerticalAlignment="Center"
+                                        ToolTipService.ToolTip="Use multiple words to narrow results"/>
 
                         <Button Grid.Column="1"
                                 Content="New Project"


### PR DESCRIPTION
Updated the project search to support multiple words, requiring all words to match in project name or description. Added a tooltip to the search box to inform users about the new multi-word search capability.